### PR TITLE
Since snaps.yaml is no longer mandatory, made the error messages less

### DIFF
--- a/cm/master.py
+++ b/cm/master.py
@@ -279,7 +279,7 @@ class ConsoleManager(BaseConsoleManager):
                              (self.app.config.get('default_bucket_url') or
                               self.app.config['bucket_default'])))
         else:
-            log.error("Couldn't get snaps.yaml at all! Will not be able to create Galaxy Data and Index volumes.")
+            log.debug("Couldn't get legacy snaps.yaml from default bucket. Assuming it's present in user data, since user data will override it anyway.")
             return []
 
         snaps_file = misc.load_yaml_file(snaps_file)

--- a/cm/util/misc.py
+++ b/cm/util/misc.py
@@ -804,10 +804,10 @@ def get_file_from_public_location(config, remote_filename, local_file):
             f.close()
             return True
         else:
-            log.warn("Could not fetch file from s3 public url: %s" % url)
+            log.debug("Could not fetch file from s3 public url: %s" % url)
             return False
     except Exception as e:
-        log.warn("Could not fetch file from s3 public url: {0} due to exception: {1}".format(url, e))
+        log.debug("Could not fetch file from s3 public url: {0} due to exception: {1}".format(url, e))
         return False
 
 


### PR DESCRIPTION
severe.