### PR TITLE
Remove the nginx rule for admin/jobs 

### DIFF
--- a/cm/conftemplates/nginx.conf.default
+++ b/cm/conftemplates/nginx.conf.default
@@ -97,10 +97,6 @@ http {
             alias $galaxy_home/static/favicon.ico;
         }
 
-        location /admin/jobs {
-            proxy_pass  http://127.0.0.1:8079;
-        }
-
         location /_x_accel_redirect/ {
             internal;
             alias /;

--- a/cm/conftemplates/nginx_galaxy_locations.default
+++ b/cm/conftemplates/nginx_galaxy_locations.default
@@ -26,10 +26,6 @@
             alias $galaxy_home/static/robots.txt;
         }
 
-        location /admin/jobs {
-            proxy_pass  http://127.0.0.1:8079;
-        }
-
         location ~ ^/plugins/visualizations/ipython/static/(?<static_file>.*?)$$ {
             alias $galaxy_home/config/plugins/interactive_environments/ipython/static/$$static_file;
         }


### PR DESCRIPTION
This currently prevents admins from managing jobs as an admin since it redirects to a headless manager process.

Maybe I don't have the full context here, though -- what was the intent behind this rule?