### PR TITLE
More direct method for locating the Nginx configuration directory

### DIFF
--- a/cm/util/paths.py
+++ b/cm/util/paths.py
@@ -279,12 +279,11 @@ class PathResolver(object):
     @property
     def nginx_conf_dir(self):
         """
-        Look around at possible nginx directory locations (from published
-        images) and resort to a file system search
+        Use the running nginx to provide the location of the current nginx configuration directory
         """
-        for path in ['/etc/nginx', '/usr/nginx/conf', '/opt/galaxy/pkg/nginx/conf']:
-            if os.path.exists(path):
-                return path
+        conf_file = misc.run("{0} -t && {0} -t 2>&1 | head -n 1 | cut -d' ' -f5".format(self.nginx_executable))
+        if conf_file:
+            return conf_file.rstrip("nginx.conf\n")
         return ''
 
     @property

--- a/cm/util/paths.py
+++ b/cm/util/paths.py
@@ -282,7 +282,7 @@ class PathResolver(object):
         Use the running nginx to provide the location of the current nginx configuration directory
         """
         conf_file = misc.run("{0} -t && {0} -t 2>&1 | head -n 1 | cut -d' ' -f5".format(self.nginx_executable))
-        if conf_file:
+        if os.path.exists(conf_file.strip()):
             return conf_file.rstrip("nginx.conf\n")
         return ''
 


### PR DESCRIPTION
In the CentOS, Nginx configuration is not located in ```/etc/nginx```. A more [direct solution](https://stackoverflow.com/questions/19910042/locate-the-nginx-conf-file-my-nginx-is-actually-using) is provided. Running the test command twice is required for the purpose of the exit status for the run command. For example: 

```
>/usr/bin/foo bar
-bash: /usr/bin/foo: No such file or directory
>echo $?
127
>/usr/bin/foo bar 2>&1
-bash: /usr/bin/foo: No such file or directory
>echo $?
0
>/usr/bin/foo bar && /usr/bin/foo bar 2>&1 | head -n1 | cut -d' ' -f5
-bash: /usr/bin/foo: No such file or directory
>echo $?
127
```

Working command in shell:
```
>test=$(/usr/nginx/sbin/nginx -t && /usr/nginx/sbin/nginx -t 2>&1 | head -n1 | cut -d' ' -f5)
nginx: the configuration file /usr/nginx/conf/nginx.conf syntax is ok
nginx: configuration file /usr/nginx/conf/nginx.conf test is successful
>echo $?
0
>echo $test
/usr/nginx/conf/nginx.conf
```