### PR TITLE
InternalException retry after SlurmCTLD reconfiguration

### DIFF
--- a/cm/conftemplates/job_conf.xml
+++ b/cm/conftemplates/job_conf.xml
@@ -9,7 +9,10 @@
         <plugin id="dynamic" type="runner">
             <param id="rules_module">galaxy.jobs.rules</param>
         </plugin>
-        <plugin id="slurm" load="galaxy.jobs.runners.slurm:SlurmJobRunner" type="runner"/>
+        <plugin id="slurm" load="galaxy.jobs.runners.slurm:SlurmJobRunner" type="runner">
+            <param id="internalexception_state">error</param>
+            <param id="internalexception_retries">10</param>
+        </plugin>
         <plugin id="pulsar_rest" load="galaxy.jobs.runners.pulsar:PulsarRESTJobRunner" type="runner"/>
         <plugin id="local" load="galaxy.jobs.runners.local:LocalJobRunner" type="runner" workers="4"/>
     </plugins>


### PR DESCRIPTION
This is related to https://github.com/galaxyproject/cloudman/issues/88.
When a worker is added or removed, slurm must reconfigure after changing its configuration, which requires a restart. When the jobs were being shown as completed, I noticed that they were still running in the background, so they would appear in state OK in Galaxy, although they were still running to the end as seen on the slurm queue. This is due to the fact that when SlurmCTLD restarts, there is a interval of time in which it cannot be reached, which throws an InternalException in the job runner. By [default](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/jobs/runners/drmaa.py#L45), there are no retries and jobs are marked as OK when an exception occurs (not sure if this is a bug itself or purposeful for other exceptions). This commit changes that configuration to set the jobs as Errored when the exception is raised, but also retry before doing so, allowing SlurmCTLD to restart and carry on (10 as the number of retries is arbitrary).
I tested this over the weekend a few times, and asked Mo to test it today as well, and it does seem to fix the issue, allowing to add and remove nodes without affecting jobs. However, I am not entirely sure if this affects Galaxy in other ways (i.e. if other issues can raise an InternalException where there shouldn't be any retries, or where the state should be set to OK)
