### PR TITLE
Changing helmsman_config chart list to have keys for each chart

### DIFF
--- a/cloudman/helmsman/management/commands/helmsman_load_config.py
+++ b/cloudman/helmsman/management/commands/helmsman_load_config.py
@@ -24,7 +24,8 @@ class Command(BaseCommand):
             print("An exception occurred during helm init:", str(e))
         for repo in settings.get('repositories'):
             call_command("add_repo", repo.get('name'), repo.get('url'))
-        for chart in settings.get('charts'):
+        for chartKey in settings.get('charts'):
+            chart = settings.get('charts').get(chartKey)
             extra_args = {}
             if chart.get('namespace'):
                 extra_args["namespace"] = chart.get('namespace')

--- a/cloudman/helmsman/management/commands/helmsman_load_config.py
+++ b/cloudman/helmsman/management/commands/helmsman_load_config.py
@@ -25,7 +25,6 @@ class Command(BaseCommand):
         for repo in settings.get('repositories'):
             call_command("add_repo", repo.get('name'), repo.get('url'))
         for chartKey in settings.get('charts'):
-            chart = settings.get('charts').get(chartKey)
             extra_args = {}
             if chart.get('namespace'):
                 extra_args["namespace"] = chart.get('namespace')

--- a/cloudman/helmsman/management/commands/helmsman_load_config.py
+++ b/cloudman/helmsman/management/commands/helmsman_load_config.py
@@ -24,7 +24,7 @@ class Command(BaseCommand):
             print("An exception occurred during helm init:", str(e))
         for repo in settings.get('repositories'):
             call_command("add_repo", repo.get('name'), repo.get('url'))
-        for chartKey in settings.get('charts'):
+        for chart in settings.get('charts', {}).values():
             extra_args = {}
             if chart.get('namespace'):
                 extra_args["namespace"] = chart.get('namespace')


### PR DESCRIPTION
The key for each chart is ignored in general for the most part, but allows the `cloudman-helm` chart to internally reference specific values from each chart without relying on an index which can be unknown. Goes with: https://github.com/CloudVE/cloudman-helm/pull/5