### PR TITLE
[WIP] Use rbac instead of kube config

### DIFF
--- a/cloudman/clusterman/api.py
+++ b/cloudman/clusterman/api.py
@@ -123,8 +123,6 @@ class CMClusterService(CMService):
                 connection_settings=connection_settings,
                 autoscale=autoscale)
             cluster = self.to_api_object(obj)
-            template = cluster.get_cluster_template()
-            template.setup()
             return cluster
         except IntegrityError as e:
             raise exceptions.CMDuplicateNameException(
@@ -132,8 +130,6 @@ class CMClusterService(CMService):
 
     def update(self, cluster):
         self.check_permissions('clusters.change_cluster', cluster)
-        template = cluster.get_cluster_template()
-        template.setup()
         cluster.db_model.save()
         return cluster
 

--- a/cloudman/clusterman/clients/rancher.py
+++ b/cloudman/clusterman/clients/rancher.py
@@ -18,8 +18,6 @@ class RancherAuth(AuthBase):
 
 class RancherClient(object):
 
-    KUBE_CONFIG_URL = ("$rancher_url/v3/clusters/$cluster_id"
-                       "?action=generateKubeconfig")
     INSTALLED_APP_URL = ("$rancher_url/v3/projects/$project_id/app"
                          "?targetNamespace=galaxy-ns")
     NODE_COMMAND_URL = "$rancher_url/v3/clusterregistrationtoken"
@@ -59,9 +57,6 @@ class RancherClient(object):
     def _api_delete(self, url, data):
         return requests.delete(self._format_url(url), auth=self._get_auth(),
                                verify=False, json=data).json()
-
-    def fetch_kube_config(self):
-        return self._api_post(self.KUBE_CONFIG_URL, data=None).get('config')
 
     def get_cluster_registration_command(self):
         return self._api_post(

--- a/cloudman/clusterman/tests/test_cluster_api.py
+++ b/cloudman/clusterman/tests/test_cluster_api.py
@@ -45,11 +45,6 @@ class CMClusterServiceTestBase(APITestCase):
 
     def setUp(self):
         self.mock_client = ClientMocker(self)
-        patcher = patch('clusterman.cluster_templates.CMRancherTemplate.fetch_kube_config',
-                        new_callable=PropertyMock,
-                        return_value=load_kube_config)
-        patcher.start()
-        self.addCleanup(patcher.stop)
 
         # Patch some background celery tasks to reduce noise in the logs.
         # They don't really affect the tests

--- a/cloudman/clusterman/tests/test_mgmt_commands.py
+++ b/cloudman/clusterman/tests/test_mgmt_commands.py
@@ -29,11 +29,6 @@ class ClusterCommandTestCase(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.patcher = patch('clusterman.cluster_templates.CMRancherTemplate.fetch_kube_config',
-                             new_callable=PropertyMock,
-                             return_value=load_kube_config)
-        self.patcher.start()
-        self.addCleanup(self.patcher.stop)
         self.client.force_login(
             User.objects.get_or_create(username='admin', is_superuser=True)[0])
 


### PR DESCRIPTION
This PR removes the usage of the kubeconfig provided by Rancher, opting for rbac credentials instead. This means that cloudman will now be tied to the single cluster it's running on, and not be multi-cluster capable. However, even currently, our logic mostly assumes that anyway, because we don't yet make an attempt to activate the correct context before making kube calls. However, we could do this if we wanted to. So it's a matter of deciding which way we want to go.