### PR TITLE
Make sure project namespace is used instead of project name

### DIFF
--- a/cloudman/helmsman/tests/data/helmsman_config.yaml
+++ b/cloudman/helmsman/tests/data/helmsman_config.yaml
@@ -23,9 +23,9 @@ install_templates:
       template: |
         ingress:
           enabled: true
-          path: '/{{context.project}}/jupyterhub'
+          path: '{{context.project.access_path}}/jupyterhub'
         hub:
-          baseUrl: '/{{context.project}}/jupyterhub'
+          baseUrl: '{{context.project.access_path}}/jupyterhub'
         proxy:
           secretToken: '{{random_alphanumeric(65)}}'
     galaxy:
@@ -41,7 +41,7 @@ install_templates:
                     <url>https://ngkc4.cloudve.org/auth</url>
                     <client_id>galaxy-auth</client_id>
                     <client_secret>{{random_alphanumeric(8)}}-{{random_alphanumeric(4)}}-{{random_alphanumeric(4)}}-{{random_alphanumeric(12)}}</client_secret>
-                    <redirect_uri>https://ngkc4.cloudve.org/{{context.project}}/galaxy/authnz/custos/callback</redirect_uri>
+                    <redirect_uri>https://ngkc4.cloudve.org{{context.project.access_path}}/galaxy/authnz/custos/callback</redirect_uri>
                     <realm>master</realm>
                 </provider>
             </OIDC>
@@ -65,7 +65,7 @@ install_templates:
           enabled: true
           hosts:
             - ngkc4.cloudve.org
-          path: /{{context.project}}/galaxy
+          path: {{context.project.access_path}}/galaxy
           tls:
             - hosts:
                 - ngkc4.cloudve.org

--- a/cloudman/helmsman/tests/test_helmsman_api.py
+++ b/cloudman/helmsman/tests/test_helmsman_api.py
@@ -252,9 +252,9 @@ class InstallTemplateServiceTests(HelmsManServiceTestBase):
         'context': {'project': 'test'},
         'template': """ingress:
               enabled: true
-              path: '/{{context.project}}/galaxy'
+              path: '{{context.project.access_path}}/galaxy'
             hub:
-              baseUrl: '/{{context.project}}/galaxy'
+              baseUrl: '{{context.project.access_path}}/galaxy'
             proxy:
               secretToken: '{{random_alphanumeric(65)}}'"""
     }

--- a/cloudman/projman/tests/data/helmsman_config.yaml
+++ b/cloudman/projman/tests/data/helmsman_config.yaml
@@ -10,9 +10,9 @@ install_templates:
       template: |
         ingress:
           enabled: true
-          path: '/{{context.project}}/jupyterhub'
+          path: '{{context.project.access_path}}/jupyterhub'
         hub:
-          baseUrl: '/{{context.project}}/jupyterhub'
+          baseUrl: '{{context.project.access_path}}/jupyterhub'
         proxy:
           secretToken: '{{random_alphanumeric(65)}}'
     galaxy:
@@ -30,7 +30,7 @@ install_templates:
                     <url>https://ngkc4.cloudve.org/auth</url>
                     <client_id>galaxy-auth</client_id>
                     <client_secret>{{random_alphanumeric(8)}}-{{random_alphanumeric(4)}}-{{random_alphanumeric(4)}}-{{random_alphanumeric(12)}}</client_secret>
-                    <redirect_uri>https://ngkc4.cloudve.org/{{context.project}}/galaxy/authnz/custos/callback</redirect_uri>
+                    <redirect_uri>https://ngkc4.cloudve.org{{context.project.access_path}}/galaxy/authnz/custos/callback</redirect_uri>
                     <realm>master</realm>
                 </provider>
             </OIDC>
@@ -54,7 +54,7 @@ install_templates:
           enabled: true
           hosts:
             - ngkc4.cloudve.org
-          path: /{{context.project}}/galaxy
+          path: {{context.project.access_path}}/galaxy
           tls:
             - hosts:
                 - ngkc4.cloudve.org


### PR DESCRIPTION
Currently, some places in the code is using project.name instead of project.namespace, which results in errors if the project.name has spaces or is not RFC1123 compliant.
It looks like we also need more than just project.name in the context. Have added the following:
```
context.project.name
context.project.namespace
context.project.access_path
```

Will probably need the domain name in the context too.