### PR TITLE
Adding 'ipaddr' filter to jinja2

### DIFF
--- a/cloudman/helmsman/tests/test_helmsman_unit.py
+++ b/cloudman/helmsman/tests/test_helmsman_unit.py
@@ -1,0 +1,42 @@
+from unittest import TestCase
+
+from django.contrib.auth.models import User
+
+from helmsman.api import HelmsManAPI
+from helmsman.api import HMServiceContext
+
+class InstallTemplateUnitTest(TestCase):
+
+
+    def setUp(self):
+        admin = User.objects.get_or_create(username='admin', is_superuser=True)[0]
+        self.client = HelmsManAPI(HMServiceContext(user=admin))
+
+    def test_render_values(self):
+        base_tpl = """
+                hosts:
+                  - ~
+                {% if not (server_host | ipaddr) %}
+                  - "{{ server_host }}"
+                {% endif %}
+        """
+
+        tpl = self.client.templates.create(
+                        'dummytpl', 'dummyrepo', 'dummychart',
+                        template=base_tpl)
+
+        ip_expected = """
+                hosts:
+                  - ~
+        """
+        host_expected = """
+                hosts:
+                  - ~
+                  - "example.com"
+        """
+
+        ip_rendered = tpl.render_values(context={'server_host': '192.168.2.1'})
+        self.assertEquals(ip_expected, ip_rendered)
+
+        host_rendered = tpl.render_values(context={'server_host': 'example.com'})
+        self.assertEquals(host_expected, host_rendered)


### PR DESCRIPTION
This to be able to check if the domain is an ip address in templates, same as we were previously doing in CM-boot: https://github.com/galaxyproject/cloudlaunch-registry/blob/master/app-registry.yaml#L2240