### PR TITLE
Hardcode keycloak namespace

### DIFF
--- a/cloudman/projman/api.py
+++ b/cloudman/projman/api.py
@@ -196,7 +196,7 @@ class PMProjectChartService(PMService):
     def _get_project_oidc_secret(self):
         try:
             secret = KubeClient().secrets.get(f"keycloak-client-secret-projman-{self.project.namespace}",
-                                              namespace=self.project.namespace)
+                                              namespace="keycloak")
             return base64.b64decode(secret.get('data').get('CLIENT_SECRET')).decode('utf-8')
         except Exception:
             return None


### PR DESCRIPTION
At least with out-of-the-box configurations, it seems keycloak operator only tracks its own namespace.
In projman, I set the clients to be deployed in the Keycloak operator namespace: https://github.com/CloudVE/projman-helm/blob/master/projman/values.yaml#L47 but it's still settable. It'd be ideal to have it a config option here as well, but not entirely sure what the most elegant way to do it is off the top of my head. Hardcoding it is also probably fine for our realistic usecases