### PR TITLE
Update requirements and add container building GHA

### DIFF
--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -1,0 +1,24 @@
+name: Build Image
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - 'master'
+jobs:
+  build:
+    name: Build image
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - run: docker build . -t galaxy/cloudman-server:latest
+      - name: Login to docker hub
+        uses: actions-hub/docker/login@master
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Push to docker hub
+        uses: actions-hub/docker@master
+        with:
+          args: push galaxy/cloudman-server:latest

--- a/cloudman/cloudman/settings.py
+++ b/cloudman/cloudman/settings.py
@@ -96,7 +96,7 @@ if os.path.isfile(CM_GLOBAL_CONTEXT_PATH) and os.access(CM_GLOBAL_CONTEXT_PATH, 
     import yaml
     with open(CM_GLOBAL_CONTEXT_PATH) as f:
         print(f"Loading cloudman global context from: {CM_GLOBAL_CONTEXT_PATH}")
-        CM_GLOBAL_CONTEXT = yaml.load(f)
+        CM_GLOBAL_CONTEXT = yaml.safe_load(f)
 else:
     CM_GLOBAL_CONTEXT = {}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # needed by celery
 sqlalchemy
+pyYAML<6.0
 # install edge till this is released: https://github.com/encode/django-rest-framework/pull/7571
 git+https://github.com/encode/django-rest-framework
 # install edge till this is released: https://github.com/celery/django-celery-results/issues/157
@@ -10,7 +11,7 @@ pydevd>=1.0.0
 # jinja2 for rendering install templates
 jinja2
 # get latest package versions for now
-git+https://github.com/CloudVE/cloudbridge
+git+https://github.com/CloudVE/cloudbridge#egg=cloudbridge[full]
 git+https://github.com/CloudVE/djcloudbridge
 # Leave cloudlaunch-cli before cloudlaunch-server due to coreapi version mismatch
 git+https://github.com/CloudVE/cloudlaunch-cli

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 # needed by celery
 sqlalchemy
-pyYAML<6.0
 # install edge till this is released: https://github.com/encode/django-rest-framework/pull/7571
 git+https://github.com/encode/django-rest-framework
 # install edge till this is released: https://github.com/celery/django-celery-results/issues/157


### PR DESCRIPTION
- pyYAML<6.0 because of `TypeError: load() missing 1 required positional argument: 'Loader'` in `yaml.load()` for 6.0+
- [full] to cloudbridge to properly include all requirements
- Adds building and pushing workflow (I don't have permissions to add secrets for this repo, so docker creds will still need to be added)
Existing image with these changes at `almahmoud/cloudman-server:latest` if you want to try it out first